### PR TITLE
Update dooya-dt82tv.json

### DIFF
--- a/templates/sprut-mqtt/dooya-dt82tv.json
+++ b/templates/sprut-mqtt/dooya-dt82tv.json
@@ -10,7 +10,7 @@
           "type": "CurrentPosition",
           "link": {
             "type": "Integer",
-            "topicSearch": "/devices/(dooya_[x0-9]{6})/controls/(Position)/meta/type",
+            "topicSearch": "/devices/(dooya_[x0-9a-f]{6})/controls/(Position)/meta/type",
             "topicGet": "/devices/(1)/controls/(2)"
           }
         },


### PR DESCRIPTION
hex format can contains not only digits but a-f as well

As the result the template didn't work as I use >10 addresses (0x0a01, 0x0b01 etc).  

Thanks for the templates, it helped me to quick adding the curtains :)

Спасибо за шаблон, респект! :+1: